### PR TITLE
Add toEqualCaseInsensitive matcher

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -20,6 +20,16 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "btnwtn",
+      "name": "Brandon Newton",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/20847518?v=4",
+      "profile": "https://btnwtn.com",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ test('passes when given an empty array', () => {
   expect([]).toBeEmpty();
   expect(['hello']).not.toBeEmpty();
 });
+
+test('passes when given an empty object', () => {
+  expect({}).toBeEmpty();
+  expect({ hello: 'world' }).not.toBeEmpty();
+});
 ```
 
 ### .toBeWithin(start, end)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
   * [.toInclude(substring)](#toincludesubstring)
   * [.toIncludeRepeated(substring, times)](#toincluderepeatedsubstring-times)
   * [.toIncludeMultiple([substring])](#toincludemultiplesubstring)
-  * [.toEqualIgnoringCase(string)](#toequalignoringcasestring)
+  * [.toEqualCaseInsensitive(string)](#toequalcaseinsensitive)
 - [Contributors](#contributors)
 - [LICENSE](#license)
 
@@ -719,27 +719,25 @@ test('passes when value includes all substrings', () => {
 });
 ```
 
-### .toEqualIgnoringCase(string)
+### .toEqualCaseInsensitive(string)
 
-_Note: Currently unimplemented_
-
-Use `.toEqualIgnoringCase` when checking if a string is equal (===) to another ignoring the casing of both strings.
+Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
 
 ```js
 test('passes when strings are equal ignoring case', () => {
-  expect('hello world').toEqualIgnoringCase('hello world');
-  expect('hello WORLD').toEqualIgnoringCase('HELLO world');
-  expect('HELLO WORLD').toEqualIgnoringCase('hello world');
-  expect('hello world').toEqualIgnoringCase('HELLO WORLD');
-  expect('hello world').not.toEqualIgnoringCase('hello');
+  expect('hello world').toEqualCaseInsensitive('hello world');
+  expect('hello WORLD').toEqualCaseInsensitive('HELLO world');
+  expect('HELLO WORLD').toEqualCaseInsensitive('hello world');
+  expect('hello world').toEqualCaseInsensitive('HELLO WORLD');
+  expect('hello world').not.toEqualCaseInsensitive('hello');
 });
 ```
 
 ## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars0.githubusercontent.com/u/5610087?v=4" width="100px;"/><br /><sub>Matt Phillips</sub>](http://mattphillips.io)<br />[📝](#blog-mattphillips "Blogposts") [💻](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Code") [📖](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Documentation") [💡](#example-mattphillips "Examples") [🚇](#infra-mattphillips "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Tests") |
-| :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/5610087?v=4" width="100px;"/><br /><sub>Matt Phillips</sub>](http://mattphillips.io)<br />[📝](#blog-mattphillips "Blogposts") [💻](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Code") [📖](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Documentation") [💡](#example-mattphillips "Examples") [🚇](#infra-mattphillips "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Tests") | [<img src="https://avatars1.githubusercontent.com/u/20847518?v=4" width="100px;"/><br /><sub>Brandon Newton</sub>](https://btnwtn.com)<br /> |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## LICENSE

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "chalk": "^2.2.0",
+    "jest-diff": "^21.2.1",
     "jest-matcher-utils": "^21.2.1"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "dependencies": {
     "chalk": "^2.2.0",
-    "jest-diff": "^21.2.1",
     "expect": "^21.2.1",
     "jest-matcher-utils": "^21.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "dependencies": {
     "chalk": "^2.2.0",
-    "jest-diff": "^21.2.1",
     "jest-matcher-utils": "^21.2.1"
   },
   "lint-staged": {

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -1,3 +1,4 @@
 import toBeTrue from './toBeTrue';
+import toEqualCaseInsensitive from './toEqualCaseInsensitive';
 
-export default [toBeTrue].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});
+export default [toBeTrue, toEqualCaseInsensitive].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});

--- a/src/matchers/toEqualCaseInsensitive/__snapshots__/index.test.js.snap
+++ b/src/matchers/toEqualCaseInsensitive/__snapshots__/index.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toEqualCaseInsensitive fails if strings do not match 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqualCaseInsensitive(</><green>expected</><dim>)</>
+
+Expected values to not be equal while ignoring case (using ===):
+  <green>\\"aaaa\\"</>
+Received:
+  <red>\\"aaaa\\"</>"
+`;
+
+exports[`.toEqualCaseInsensitive passes if strings are equal despite case 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqualCaseInsensitive(</><green>expected</><dim>)</>
+
+Expected values to be equal while ignoring case (using ===):
+  <green>\\"bbbb\\"</>
+Received:
+  <red>\\"aaaa\\"</>"
+`;

--- a/src/matchers/toEqualCaseInsensitive/index.js
+++ b/src/matchers/toEqualCaseInsensitive/index.js
@@ -1,9 +1,42 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import diff from 'jest-diff';
 import predicate from './predicate';
 
+const passMessage = (received, expected) => () => {
+  return (
+    matcherHint('.not.toEqualCaseInsensitive') +
+    '\n\n' +
+    'Expected values to not be equal (using ===):\n' +
+    `  ${printExpected(expected)}\n` +
+    'Received:\n' +
+    `  ${printReceived(received)}`
+  );
+};
+
+const failMessage = (received, expected) => () => {
+  const diffString = diff(expected, received, {
+    expand: this.expand
+  });
+
+  return (
+    matcherHint('.toEqualCaseInsensitive') +
+    '\n\n' +
+    'Expected values to be equal (using ===):\n' +
+    `  ${printExpected(expected)}\n` +
+    'Received:\n' +
+    `  ${printReceived(received)}` +
+    (diffString ? `\n\nDifference:\n\n${diffString}` : '')
+  );
+};
+
 export default {
-  toEqualCaseInsensitive: (received, expected) => {
+  toEqualCaseInsensitive(received, expected) {
     const pass = predicate(received, expected);
 
-    return { pass, message: 'lol', actual: received };
+    return {
+      pass,
+      message: pass ? passMessage(received, expected) : failMessage(received, expected),
+      actual: received
+    };
   }
 };

--- a/src/matchers/toEqualCaseInsensitive/index.js
+++ b/src/matchers/toEqualCaseInsensitive/index.js
@@ -1,12 +1,11 @@
 import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-import diff from 'jest-diff';
 import predicate from './predicate';
 
 const passMessage = (received, expected) => () => {
   return (
     matcherHint('.not.toEqualCaseInsensitive') +
     '\n\n' +
-    'Expected values to not be equal (using ===):\n' +
+    'Expected values to not be equal while ignoring case (using ===):\n' +
     `  ${printExpected(expected)}\n` +
     'Received:\n' +
     `  ${printReceived(received)}`
@@ -14,18 +13,13 @@ const passMessage = (received, expected) => () => {
 };
 
 const failMessage = (received, expected) => () => {
-  const diffString = diff(expected, received, {
-    expand: this.expand
-  });
-
   return (
     matcherHint('.toEqualCaseInsensitive') +
     '\n\n' +
-    'Expected values to be equal (using ===):\n' +
+    'Expected values to be equal while ignoring case (using ===):\n' +
     `  ${printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(received)}` +
-    (diffString ? `\n\nDifference:\n\n${diffString}` : '')
+    `  ${printReceived(received)}`
   );
 };
 

--- a/src/matchers/toEqualCaseInsensitive/index.js
+++ b/src/matchers/toEqualCaseInsensitive/index.js
@@ -1,0 +1,9 @@
+import predicate from './predicate';
+
+export default {
+  toEqualCaseInsensitive: (received, expected) => {
+    const pass = predicate(received, expected);
+
+    return { pass, message: 'lol', actual: received };
+  }
+};

--- a/src/matchers/toEqualCaseInsensitive/index.test.js
+++ b/src/matchers/toEqualCaseInsensitive/index.test.js
@@ -8,11 +8,13 @@ describe('.toEqualCaseInsensitive', () => {
     expect('aaAA').toEqualCaseInsensitive('aaaa');
     expect('HELLO WORLD').toEqualCaseInsensitive('hello world');
     expect('hello world').toEqualCaseInsensitive('HELLO WORLD');
+    expect(() => expect('aaaa').toEqualCaseInsensitive('bbbb')).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toEqualCaseInsensitive', () => {
   it('fails if strings do not match', () => {
     expect('hello world').not.toEqualCaseInsensitive('hello');
+    expect(() => expect('aaaa').not.toEqualCaseInsensitive('aaaa')).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toEqualCaseInsensitive/index.test.js
+++ b/src/matchers/toEqualCaseInsensitive/index.test.js
@@ -1,0 +1,18 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toEqualCaseInsensitive', () => {
+  it('passes if strings are equal despite case', () => {
+    expect('hello world').toEqualCaseInsensitive('hello world');
+    expect('hello WORLD').toEqualCaseInsensitive('HELLO world');
+    expect('HELLO WORLD').toEqualCaseInsensitive('hello world');
+    expect('hello world').toEqualCaseInsensitive('HELLO WORLD');
+  });
+});
+
+describe('.not.toEqualCaseInsensitive', () => {
+  it('fails if strings do not match', () => {
+    expect('hello world').not.toEqualCaseInsensitive('hello');
+  });
+});

--- a/src/matchers/toEqualCaseInsensitive/index.test.js
+++ b/src/matchers/toEqualCaseInsensitive/index.test.js
@@ -4,8 +4,8 @@ expect.extend(matcher);
 
 describe('.toEqualCaseInsensitive', () => {
   it('passes if strings are equal despite case', () => {
-    expect('hello world').toEqualCaseInsensitive('hello world');
-    expect('hello WORLD').toEqualCaseInsensitive('HELLO world');
+    expect('a').toEqualCaseInsensitive('A');
+    expect('aaAA').toEqualCaseInsensitive('aaaa');
     expect('HELLO WORLD').toEqualCaseInsensitive('hello world');
     expect('hello world').toEqualCaseInsensitive('HELLO WORLD');
   });

--- a/src/matchers/toEqualCaseInsensitive/predicate.js
+++ b/src/matchers/toEqualCaseInsensitive/predicate.js
@@ -1,0 +1,1 @@
+export default (a, b) => String(a).toLowerCase() === String(b).toLowerCase();

--- a/src/matchers/toEqualCaseInsensitive/predicate.test.js
+++ b/src/matchers/toEqualCaseInsensitive/predicate.test.js
@@ -1,0 +1,13 @@
+import predicate from './predicate';
+
+describe('toEqualCaseInsensitive Predicate', () => {
+  it('returns true given equal strings regardless of case', () => {
+    expect(predicate('hello WORLD', 'hello world')).toEqual(true);
+    expect(predicate('HeLLo WORLD', 'hello world')).toEqual(true);
+    expect(predicate('HELLO WORLD', 'hello world')).toEqual(true);
+  });
+
+  it('returns false when given two different strings', () => {
+    expect(predicate('hello', 'world')).toEqual(false);
+  });
+});


### PR DESCRIPTION
<!-- What changes are being made? (feature/bug) -->
### What
I'm proposing changing the name of the matcher from `toEqualIgnoringCase` to `toEqualCaseInsensitive`.
I think it better explains what the matcher does, opinions?

<!-- Why are these changes necessary? Link any related issues -->
### Why
Feature request by: #44 

<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
