### PR TITLE
To be string

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,14 +608,13 @@ test('passes when value is an array', () => {
 
 ### .toBeString()
 
-_Note: Currently unimplemented_
-
 Use `.toBeString` when checking if a value is a `String`.
 
 ```js
 test('passes when value is a string', () => {
   expect('').toBeString();
   expect('hello').toBeString();
+  expect(new String('hello')).toBeString();
   expect(true).not.toBeString();
 });
 ```

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -1,5 +1,9 @@
+import toBeString from './toBeString';
 import toBeTrue from './toBeTrue';
 import toContainValue from './toContainValue';
 import toContainValues from './toContainValues';
 
-export default [toBeTrue, toContainValue, toContainValues].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});
+export default [toBeString, toBeTrue, toContainValue, toContainValues].reduce(
+  (acc, matcher) => ({ ...acc, ...matcher }),
+  {}
+);

--- a/src/matchers/toBeString/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeString/__snapshots__/index.test.js.snap
@@ -14,4 +14,11 @@ Expected value to not be of type string received:
   <red>{\\"0\\": \\"s\\", \\"1\\": \\"t\\", \\"10\\": \\"e\\", \\"2\\": \\"r\\", \\"3\\": \\"i\\", \\"4\\": \\"n\\", \\"5\\": \\"g\\", \\"6\\": \\" \\", \\"7\\": \\"t\\", \\"8\\": \\"y\\", \\"9\\": \\"p\\"}</>"
 `;
 
-exports[`.toBeString fails when not given a string 1`] = `"string is not defined"`;
+exports[`.toBeString fails when not given a string 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeString(</><dim>)</>
+
+Expected value to be of type string:
+  <green>\\"type of string\\"</>
+Received:
+  <red>\\"number\\"</>"
+`;

--- a/src/matchers/toBeString/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeString/__snapshots__/index.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeString fails when given a string literal 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeString(</><dim>)</>
+
+Expected value to not be of type string received:
+  <red>\\"\\"</>"
+`;
+
+exports[`.not.toBeString fails when given an object of type string 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeString(</><dim>)</>
+
+Expected value to not be of type string received:
+  <red>{\\"0\\": \\"s\\", \\"1\\": \\"t\\", \\"10\\": \\"e\\", \\"2\\": \\"r\\", \\"3\\": \\"i\\", \\"4\\": \\"n\\", \\"5\\": \\"g\\", \\"6\\": \\" \\", \\"7\\": \\"t\\", \\"8\\": \\"y\\", \\"9\\": \\"p\\"}</>"
+`;
+
+exports[`.toBeString fails when not given a string 1`] = `"string is not defined"`;

--- a/src/matchers/toBeString/index.js
+++ b/src/matchers/toBeString/index.js
@@ -1,0 +1,28 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = received => () =>
+  matcherHint('.not.toBeString', 'received', '') +
+  '\n\n' +
+  'Expected value to not be of type string received:\n' +
+  `  ${printReceived(received)}`;
+
+const failMessage = received => () =>
+  matcherHint('.toBeString', 'received', '') +
+  '\n\n' +
+  'Expected value to be of type string:\n' +
+  `  ${printExpected(string)}\n` +
+  'Received:\n' +
+  `  ${printReceived(typeof received)}`;
+
+export default {
+  toBeString: expected => {
+    const pass = predicate(expected);
+    if (pass) {
+      return { pass: true, message: passMessage(expected) };
+    }
+
+    return { pass: false, message: failMessage(expected) };
+  }
+};

--- a/src/matchers/toBeString/index.js
+++ b/src/matchers/toBeString/index.js
@@ -12,7 +12,7 @@ const failMessage = received => () =>
   matcherHint('.toBeString', 'received', '') +
   '\n\n' +
   'Expected value to be of type string:\n' +
-  `  ${printExpected(string)}\n` +
+  `  ${printExpected('type of string')}\n` +
   'Received:\n' +
   `  ${printReceived(typeof received)}`;
 

--- a/src/matchers/toBeString/index.test.js
+++ b/src/matchers/toBeString/index.test.js
@@ -1,0 +1,42 @@
+import each from 'jest-each';
+
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeString', () => {
+  it('passes when given a string literal', () => {
+    expect('string type').toBeString();
+  });
+
+  it('passes when given an object of type string', () => {
+    expect(new String('string type')).toBeString();
+  });
+
+  it('fails when not given a string', () => {
+    expect(() => expect(5).toBeString()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeString', () => {
+  each([
+    [false],
+    [0],
+    [{}],
+    [[]],
+    [() => {}],
+    [undefined],
+    [null],
+    [NaN]
+  ]).it('passes when not item is not of type string: %s', given => {
+    expect(given).not.toBeString();
+  });
+
+  it('fails when given a string literal', () => {
+    expect(() => expect('').not.toBeString()).toThrowErrorMatchingSnapshot();
+  });
+
+  it('fails when given an object of type string', () => {
+    expect(() => expect(new String('string type')).not.toBeString()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeString/predicate.js
+++ b/src/matchers/toBeString/predicate.js
@@ -1,0 +1,3 @@
+export default expected => {
+  return typeof expected === 'string' || expected instanceof String;
+};

--- a/src/matchers/toBeString/predicate.test.js
+++ b/src/matchers/toBeString/predicate.test.js
@@ -1,0 +1,16 @@
+import each from 'jest-each';
+import predicate from './predicate';
+
+describe('toBeString Predicate', () => {
+  it('returns true when given a string literal', () => {
+    expect(predicate('string example')).toBe(true);
+  });
+
+  it('returns true when given a string object', () => {
+    expect(predicate(new String('string example'))).toBe(true);
+  });
+
+  each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it('returns false when given: %s', given => {
+    expect(predicate(given)).toBe(false);
+  });
+});


### PR DESCRIPTION
### What
Added the toBeString matcher.

### Why
Issue [#36](https://github.com/mattphillips/jest-extended/issues/36)

### Notes
I saw the previous pull request to late but this PR also added the case to match String objects created with new String('gewgew')