### PR TITLE
Add to start with matcher

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -20,6 +20,15 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "GaryLeutheuser",
+      "name": "Gary Leutheuser",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/8472688?v=4",
+      "profile": "https://GaryLeutheuser.github.io",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -656,8 +656,6 @@ test('passes when value is a boolean', () => {
 
 ### .toStartWith(prefix)
 
-_Note: Currently unimplemented_
-
 Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
 
 ```js
@@ -738,8 +736,8 @@ test('passes when strings are equal ignoring case', () => {
 ## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars0.githubusercontent.com/u/5610087?v=4" width="100px;"/><br /><sub>Matt Phillips</sub>](http://mattphillips.io)<br />[📝](#blog-mattphillips "Blogposts") [💻](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Code") [📖](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Documentation") [💡](#example-mattphillips "Examples") [🚇](#infra-mattphillips "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Tests") |
-| :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/5610087?v=4" width="100px;"/><br /><sub>Matt Phillips</sub>](http://mattphillips.io)<br />[📝](#blog-mattphillips "Blogposts") [💻](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Code") [📖](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Documentation") [💡](#example-mattphillips "Examples") [🚇](#infra-mattphillips "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/mattphillips/jest-extended/commits?author=mattphillips "Tests") | [<img src="https://avatars2.githubusercontent.com/u/8472688?v=4" width="100px;"/><br /><sub>Gary Leutheuser</sub>](https://GaryLeutheuser.github.io)<br />[💻](https://github.com/mattphillips/jest-extended/commits?author=GaryLeutheuser "Code") |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## LICENSE

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -1,3 +1,4 @@
 import toBeTrue from './toBeTrue';
+import toStartWith from './toStartWith';
 
 export default [toBeTrue].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -1,4 +1,4 @@
 import toBeTrue from './toBeTrue';
 import toStartWith from './toStartWith';
 
-export default [toBeTrue].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});
+export default [toBeTrue, toStartWith].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});

--- a/src/matchers/toStartWith/__snapshots__/index.test.js.snap
+++ b/src/matchers/toStartWith/__snapshots__/index.test.js.snap
@@ -3,7 +3,9 @@
 exports[`.not.toStartWith fails when string starts with given prefix 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toStartWith(</><dim>)</>
 
-Expected string to not start with received:
+Expected string to not start with:
+  <red>\\"hello\\"</>
+Received:
   <red>\\"hello\\"</>"
 `;
 

--- a/src/matchers/toStartWith/__snapshots__/index.test.js.snap
+++ b/src/matchers/toStartWith/__snapshots__/index.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toStartWith fails when string starts with given prefix 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toStartWith(</><dim>)</>
+
+Expected string to not start with received:
+  <red>\\"hello\\"</>"
+`;
+
+exports[`.toStartWith fails when string does not start with the given prefix 1`] = `
+"<dim>expect(</><red>received</><dim>).toStartWith(</><dim>)</>
+
+Expected string to start with:
+  <green>\\"world\\"</>
+String started with:
+  <red>\\"hello\\"</>"
+`;
+
+exports[`.toStartWith fails when the string is shorter than the given prefix 1`] = `
+"<dim>expect(</><red>received</><dim>).toStartWith(</><dim>)</>
+
+Expected string to start with:
+  <green>\\"hello world\\"</>
+String started with:
+  <red>\\"hello\\"</>"
+`;

--- a/src/matchers/toStartWith/index.js
+++ b/src/matchers/toStartWith/index.js
@@ -5,7 +5,9 @@ import predicate from './predicate';
 const passMessage = (prefix, string) => () =>
   matcherHint('.not.toStartWith', 'received', '') +
   '\n\n' +
-  'Expected string to not start with received:\n' +
+  'Expected string to not start with:\n' +
+  `  ${printReceived(prefix)}\n` +
+  'Received:\n' +
   `  ${printReceived(prefix)}`;
 
 const failMessage = (prefix, string) => () =>

--- a/src/matchers/toStartWith/index.js
+++ b/src/matchers/toStartWith/index.js
@@ -1,0 +1,28 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (prefix, string) => () =>
+  matcherHint('.not.toStartWith', 'received', '') +
+  '\n\n' +
+  'Expected string to not start with received:\n' +
+  `  ${printReceived(prefix)}`;
+
+const failMessage = (prefix, string) => () =>
+  matcherHint('.toStartWith', 'received', '') +
+  '\n\n' +
+  'Expected string to start with:\n' +
+  `  ${printExpected(prefix)}\n` +
+  'String started with:\n' +
+  `  ${printReceived(string.substring(0, prefix.length))}`;
+
+export default {
+  toStartWith: (string, prefix) => {
+    const pass = predicate(prefix, string);
+    if (pass) {
+      return { pass: true, message: passMessage(prefix, string) };
+    }
+
+    return { pass: false, message: failMessage(prefix, string) };
+  }
+};

--- a/src/matchers/toStartWith/index.test.js
+++ b/src/matchers/toStartWith/index.test.js
@@ -1,0 +1,33 @@
+import each from 'jest-each';
+
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toStartWith', () => {
+  it('passes when string starts with given prefix', () => {
+    expect('hello world').toStartWith('hello');
+  });
+
+  it('fails when the string is shorter than the given prefix', () => {
+    expect(() => expect('hello').toStartWith('hello world')).toThrowErrorMatchingSnapshot();
+  });
+
+  it('fails when string does not start with the given prefix', () => {
+    expect(() => expect('hello world').toStartWith('world')).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toStartWith', () => {
+  it('passes when string does not start with the given prefix', () => {
+    expect('hello world').not.toStartWith('world');
+  });
+
+  it('passes when string is shorter than the given prefix', () => {
+    expect('hello').not.toStartWith('hello world');
+  });
+
+  it('fails when string starts with given prefix', () => {
+    expect(() => expect('hello world').not.toStartWith('hello')).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toStartWith/predicate.js
+++ b/src/matchers/toStartWith/predicate.js
@@ -1,0 +1,1 @@
+export default (prefix, string) => prefix === string.substring(0, prefix.length);

--- a/src/matchers/toStartWith/predicate.js
+++ b/src/matchers/toStartWith/predicate.js
@@ -1,1 +1,1 @@
-export default (prefix, string) => prefix === string.substring(0, prefix.length);
+export default (prefix, string) => string.startsWith(prefix);

--- a/src/matchers/toStartWith/predicate.test.js
+++ b/src/matchers/toStartWith/predicate.test.js
@@ -1,0 +1,12 @@
+import each from 'jest-each';
+import predicate from './predicate';
+
+describe('toStartWith Predicate', () => {
+  it('returns true when string starts with given prefix', () => {
+    expect(predicate('hello', 'hello world')).toBe(true);
+  });
+
+  it('returns false when string does not start with given prefix', () => {
+    expect(predicate('world', 'hello world')).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Implementation of the `toStartWith` matcher.

<!-- Why are these changes necessary? Link any related issues -->
### Why
This implementation addresses #39.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
