### PR TITLE
yarn contributor:generate don't exist in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ yarn contributor <YOUR_GITHUB_USERNAME>
 Follow the prompt. If you've already added yourself to the list and are making a
 new type of contribution, you can run it again and select the added contribution
 type. If you need to edit the `.all-contributorsrc` file by hand that's fine
-too, just run `yarn contributor:generate` to regenerate the table
+too, just run `yarn contributor:gen` to regenerate the table
 
 ## Help needed
 


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
bug

<!-- Why are these changes necessary? Link any related issues -->
### Why
So correct script name is used in CONTRIBUTING.md

<!-- If necessary add any additional notes on the implementation -->
### Notes
Hope its ok that i did not do a issue for this.
Another solution could be to update package.json instead.

### Housekeeping

- [ ] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
